### PR TITLE
Update constructor and fix docstrings

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -20,7 +20,7 @@ const EDGE_DENSITIES = [
 
 # Helper functions for benchmarking
 function create_test_graph(nvars::Int, nfacts::Int, avg_edges_per_node::Int)
-    g = BipartiteFactorGraph{Float64, String, Int}()
+    g = BipartiteFactorGraph(Float64, String, Int)
 
     # Add variables and factors
     for i in 1:nvars
@@ -62,11 +62,11 @@ end
 
 # Setup functions to avoid scope issues
 function setup_empty_graph()
-    return BipartiteFactorGraph{Float64, String, Int}()
+    return BipartiteFactorGraph(Float64, String, Int)
 end
 
 function setup_graph_with_vars(nvars)
-    g = BipartiteFactorGraph{Float64, String, Int}()
+    g = BipartiteFactorGraph(Float64, String, Int)
     for i in 1:nvars
         add_variable!(g, float(i))
     end
@@ -74,7 +74,7 @@ function setup_graph_with_vars(nvars)
 end
 
 function setup_graph_with_factors(nfacts)
-    g = BipartiteFactorGraph{Float64, String, Int}()
+    g = BipartiteFactorGraph(Float64, String, Int)
     for i in 1:nfacts
         add_factor!(g, "factor_$i")
     end
@@ -82,7 +82,7 @@ function setup_graph_with_factors(nfacts)
 end
 
 function setup_graph_with_vars_and_factors(nvars, nfacts)
-    g = BipartiteFactorGraph{Float64, String, Int}()
+    g = BipartiteFactorGraph(Float64, String, Int)
     for i in 1:nvars
         add_variable!(g, float(i))
     end
@@ -100,7 +100,7 @@ for size in GRAPH_SIZES
     nvars, nfacts = size.vars, size.facts
 
     # Graph creation
-    SUITE["creation"]["empty_$size_name"] = @benchmarkable BipartiteFactorGraph{Float64, String, Int}()
+    SUITE["creation"]["empty_$size_name"] = @benchmarkable BipartiteFactorGraph(Float64, String, Int)
 
     # Adding single variable/factor
     SUITE["creation"]["add_variable_$size_name"] = @benchmarkable add_variable!(g, 1.0) setup = (
@@ -162,10 +162,12 @@ for size in GRAPH_SIZES
                     edges_added += 1
                 end
             end
-        end setup = (g = setup_graph_with_vars_and_factors($nvars, $nfacts);
-        nvars = $nvars;
-        nfacts = $nfacts;
-        total_edges = $total_edges)
+        end setup = (
+            g = setup_graph_with_vars_and_factors($nvars, $nfacts);
+            nvars = $nvars;
+            nfacts = $nfacts;
+            total_edges = $total_edges
+        )
     end
 end
 
@@ -195,16 +197,16 @@ for size in GRAPH_SIZES
             for f in factors_sample
                 variable_neighbors(g, f)
             end
-        end setup = (g = create_test_graph($nvars, $nfacts, $avg_edges);
-        factors_sample = get_random_nodes(g, 100, :factor))
+        end setup =
+            (g = create_test_graph($nvars, $nfacts, $avg_edges); factors_sample = get_random_nodes(g, 100, :factor))
 
         # Iterate over all factor neighbors for a random variable
         SUITE["iteration"]["fac_neighbors_$(size_name)_$(density_name)"] = @benchmarkable begin
             for v in vars_sample
                 factor_neighbors(g, v)
             end
-        end setup = (g = create_test_graph($nvars, $nfacts, $avg_edges);
-        vars_sample = get_random_nodes(g, 100, :variable))
+        end setup =
+            (g = create_test_graph($nvars, $nfacts, $avg_edges); vars_sample = get_random_nodes(g, 100, :variable))
     end
 end
 
@@ -224,16 +226,16 @@ for size in GRAPH_SIZES
             for v in vars_sample
                 get_variable_data(g, v)
             end
-        end setup = (g = create_test_graph($nvars, $nfacts, $avg_edges);
-        vars_sample = get_random_nodes(g, 1000, :variable))
+        end setup =
+            (g = create_test_graph($nvars, $nfacts, $avg_edges); vars_sample = get_random_nodes(g, 1000, :variable))
 
         # Random access to factor data
         SUITE["random_access"]["fac_data_$(size_name)_$(density_name)"] = @benchmarkable begin
             for f in facts_sample
                 get_factor_data(g, f)
             end
-        end setup = (g = create_test_graph($nvars, $nfacts, $avg_edges);
-        facts_sample = get_random_nodes(g, 1000, :factor))
+        end setup =
+            (g = create_test_graph($nvars, $nfacts, $avg_edges); facts_sample = get_random_nodes(g, 1000, :factor))
 
         # Random access to edge data
         SUITE["random_access"]["edge_data_$(size_name)_$(density_name)"] = @benchmarkable begin
@@ -244,8 +246,8 @@ for size in GRAPH_SIZES
                     get_edge_data(g, v, f)
                 end
             end
-        end setup = (g = create_test_graph($nvars, $nfacts, $avg_edges);
-        vars_sample = get_random_nodes(g, 1000, :variable))
+        end setup =
+            (g = create_test_graph($nvars, $nfacts, $avg_edges); vars_sample = get_random_nodes(g, 1000, :variable))
     end
 end
 
@@ -308,9 +310,11 @@ for size in GRAPH_SIZES
                     has_edge(g, v, f)
                 end
             end
-        end setup = (g = create_test_graph($nvars, $nfacts, $avg_edges);
-        vars_sample = get_random_nodes(g, 10, :variable);
-        facts_sample = get_random_nodes(g, 10, :factor)) evals = 1
+        end setup = (
+            g = create_test_graph($nvars, $nfacts, $avg_edges);
+            vars_sample = get_random_nodes(g, 10, :variable);
+            facts_sample = get_random_nodes(g, 10, :factor)
+        ) evals = 1
 
         # Check node types - use separate setup expressions to avoid variable conflicts
         SUITE["queries"]["is_variable_$(size_name)_$(density_name)"] = @benchmarkable begin

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,7 +36,7 @@ Pkg.add("BipartiteFactorGraphs")
 using BipartiteFactorGraphs
 
 # Create a graph with Float64 variable data, String factor data, and Int edge data
-g = BipartiteFactorGraph{Float64, String, Int}()
+g = BipartiteFactorGraph(Float64, String, Int)
 
 # Add variables
 v1 = add_variable!(g, 1.0)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -13,7 +13,7 @@ using BipartiteFactorGraphs
 
 # Create a graph with Float64 for variable data, String for factor data, 
 # and Int for edge data
-g = BipartiteFactorGraph{Float64, String, Int}()
+g = BipartiteFactorGraph(Float64, String, Int)
 ```
 
 The type parameters specify:
@@ -97,7 +97,7 @@ struct EdgeData
 end
 
 # Create graph with custom types
-g = BipartiteFactorGraph{VariableData, FactorData, EdgeData}()
+g = BipartiteFactorGraph(VariableData, FactorData, EdgeData)
 
 # Add variable with custom data
 var_data = VariableData("x1", 0.5, [-1.0, 1.0])
@@ -120,7 +120,7 @@ By default, BipartiteFactorGraph uses `Dict` to store node and edge data. You ca
 using Dictionaries  # Make sure to add this package to your project
 
 # Create a graph using Dictionaries.jl
-g = BipartiteFactorGraph{Float64, String, Int}(Dictionary)
+g = BipartiteFactorGraph(Float64, String, Int, Dictionary)
 ```
 
 ## Performance Tips
@@ -141,7 +141,7 @@ using BipartiteFactorGraphs
 using LinearAlgebra
 
 # Create a simple Gaussian factor graph
-g = BipartiteFactorGraph{Vector{Float64}, Function, Matrix{Float64}}()
+g = BipartiteFactorGraph(Vector{Float64}, Function, Matrix{Float64})
 
 # Add variable nodes (mean and covariance)
 v1 = add_variable!(g, [0.0, 0.0])  # Prior belief

--- a/src/BipartiteFactorGraphs.jl
+++ b/src/BipartiteFactorGraphs.jl
@@ -38,16 +38,16 @@ Base.hash(p::UnorderedPair) = hash(p.a) + hash(p.b)
 Base.:(==)(p1::UnorderedPair, p2::UnorderedPair) = (p1.a == p2.a && p1.b == p2.b) || (p1.a == p2.b && p1.b == p2.a)
 
 """
-    BipartiteFactorGraph{TVar,TFac,E,DVars<:AbstractDict{Int,TVar},DFacs<:AbstractDict{Int,TFac},DE<:AbstractDict{Tuple{Int,Int},E}}
+    BipartiteFactorGraph
 
 A type-stable bipartite factor graph implementation that stores data for variables, factors, and edges.
 Users are responsible for maintaining the bipartite structure.
 
 # Fields
 - `graph::SimpleGraph{Int}`: The underlying graph structure
-- `variable_data::DVars`: Data for variable nodes
-- `factor_data::DFacs`: Data for factor nodes
-- `edge_data::DE`: Data for edges between variables and factors
+- `variable_data::TVar`: Data for variable nodes
+- `factor_data::TFac`: Data for factor nodes
+- `edge_data::E`: Data for edges between variables and factors
 
 To construct an empty BipartiteFactorGraph with specified variable, factor and edge data types use the following constructor:
 
@@ -103,11 +103,6 @@ function BipartiteFactorGraph(::Type{TVar}, ::Type{TFac}, ::Type{E}, dict_type::
     )
 end
 
-"""
-    Base.show(io::IO, g::BipartiteFactorGraph)
-
-Custom display method for BipartiteFactorGraph that shows the number of variables, factors, and edges.
-"""
 function Base.show(io::IO, g::BipartiteFactorGraph{TVar, TFac, E}) where {TVar, TFac, E}
     n_variables = length(g.variable_data)
     n_factors = length(g.factor_data)

--- a/src/BipartiteFactorGraphs.jl
+++ b/src/BipartiteFactorGraphs.jl
@@ -48,6 +48,36 @@ Users are responsible for maintaining the bipartite structure.
 - `variable_data::DVars`: Data for variable nodes
 - `factor_data::DFacs`: Data for factor nodes
 - `edge_data::DE`: Data for edges between variables and factors
+
+To construct an empty BipartiteFactorGraph with specified variable, factor and edge data types use the following constructor:
+
+```julia
+BipartiteFactorGraph(::Type{TVar}, ::Type{TFac}, ::Type{E}, dict_type::Type{D}=Dict) where {TVar,TFac,E,D}
+```
+
+# Arguments
+- `TVar`: The type of the variable data
+- `TFac`: The type of the factor data
+- `E`: The type of the edge data
+- `dict_type`: The type of the dictionary used to store the variable, factor and edge data (defaults to Base.Dict)
+
+As an alternative to the constructor, you can use `BipartiteFactorGraph()` as an alias to `BipartiteFactorGraph(Any, Any, Any, Dict)`.
+
+# Example
+```jldoctest
+julia> g = BipartiteFactorGraph(Int, Float64, String, Dict)
+BipartiteFactorGraph{Int64, Float64, String} with 0 variables, 0 factors, and 0 edges
+
+julia> add_variable!(g, 1);
+
+julia> add_factor!(g, 2.0);
+
+julia> add_edge!(g, 1, 2, "Hello");
+
+julia> g
+BipartiteFactorGraph{Int64, Float64, String} with 1 variables, 1 factors, and 1 edges
+```
+
 """
 struct BipartiteFactorGraph{
     TVar,
@@ -63,16 +93,28 @@ struct BipartiteFactorGraph{
     edge_data::DE
 end
 
-"""
-    BipartiteFactorGraph{TVar,TFac,E}(dict_type=Dict) where {TVar,TFac,E}
+function BipartiteFactorGraph()
+    return BipartiteFactorGraph(Any, Any, Any, Dict)
+end
 
-Construct an empty BipartiteFactorGraph with specified variable, factor and edge data types.
-Optionally specify a dictionary type (defaults to Base.Dict).
-"""
-function BipartiteFactorGraph{TVar, TFac, E}(dict_type = Dict) where {TVar, TFac, E}
-    return BipartiteFactorGraph{TVar, TFac, E, dict_type{Int, TVar}, dict_type{Int, TFac}, dict_type{UnorderedPair, E}}(
+function BipartiteFactorGraph(::Type{TVar}, ::Type{TFac}, ::Type{E}, dict_type::Type{D} = Dict) where {TVar, TFac, E, D}
+    return BipartiteFactorGraph{TVar, TFac, E, D{Int, TVar}, D{Int, TFac}, D{UnorderedPair, E}}(
         SimpleGraph{Int}(), dict_type{Int, TVar}(), dict_type{Int, TFac}(), dict_type{UnorderedPair, E}()
     )
+end
+
+"""
+    Base.show(io::IO, g::BipartiteFactorGraph)
+
+Custom display method for BipartiteFactorGraph that shows the number of variables, factors, and edges.
+"""
+function Base.show(io::IO, g::BipartiteFactorGraph{TVar, TFac, E}) where {TVar, TFac, E}
+    n_variables = length(g.variable_data)
+    n_factors = length(g.factor_data)
+    n_edges = length(g.edge_data)
+
+    print(io, "BipartiteFactorGraph{$TVar, $TFac, $E} with ")
+    print(io, "$n_variables variables, $n_factors factors, and $n_edges edges")
 end
 
 """

--- a/test/dictionaries_tests.jl
+++ b/test/dictionaries_tests.jl
@@ -2,7 +2,7 @@
     using BipartiteFactorGraphs
 
     # Test with Base.Dict (default)
-    g = BipartiteFactorGraph{Float64, String, Bool}(Dict)
+    g = BipartiteFactorGraph(Float64, String, Bool, Dict)
 
     v1 = add_variable!(g, 1.0)
     f1 = add_factor!(g, "factor1")

--- a/test/edge_cases_tests.jl
+++ b/test/edge_cases_tests.jl
@@ -1,7 +1,7 @@
 @testitem "Error handling for non-existent nodes" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Test accessing non-existent variable
     @test_throws KeyError get_variable_data(g, 1)
@@ -25,7 +25,7 @@ end
 @testitem "Edge data error handling" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     v1 = add_variable!(g, 1.0)
     v2 = add_variable!(g, 2.0)
@@ -46,7 +46,7 @@ end
 @testitem "Empty graph operations" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Test collections on empty graph
     @test isempty(variables(g))
@@ -61,7 +61,7 @@ end
     using BipartiteFactorGraphs
     using Graphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     v1 = add_variable!(g, 1.0)
     v2 = add_variable!(g, 2.0)
@@ -91,7 +91,7 @@ end
     using BipartiteFactorGraphs
 
     # Create a larger graph
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Add many variables and factors
     num_nodes = 1000
@@ -134,7 +134,7 @@ end
         metadata::Dict{Symbol, Any}
     end
 
-    g = BipartiteFactorGraph{Vector{Float64}, Dict{String, Any}, CustomEdgeData}()
+    g = BipartiteFactorGraph(Vector{Float64}, Dict{String, Any}, CustomEdgeData)
 
     # Add variable with array data
     v1 = add_variable!(g, [1.0, 2.0, 3.0])

--- a/test/graph_api_tests.jl
+++ b/test/graph_api_tests.jl
@@ -2,7 +2,7 @@
     using BipartiteFactorGraphs
     using Graphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Test empty graph properties
     @test Graphs.nv(g) == 0
@@ -47,7 +47,7 @@
     @test Graphs.density(g) == 4 / 6
 
     # Test with larger graph
-    h = BipartiteFactorGraph{Int, String, Bool}()
+    h = BipartiteFactorGraph(Int, String, Bool)
 
     # Add 10 variables and 5 factors
     for i in 1:10
@@ -84,7 +84,7 @@ end
     using Graphs
 
     # Test with only variables, no factors
-    g1 = BipartiteFactorGraph{Float64, String, Bool}()
+    g1 = BipartiteFactorGraph(Float64, String, Bool)
     for i in 1:5
         add_variable!(g1, Float64(i))
     end
@@ -94,7 +94,7 @@ end
     @test Graphs.density(g1) == 0.0  # No factors means no possible edges
 
     # Test with only factors, no variables
-    g2 = BipartiteFactorGraph{Float64, String, Bool}()
+    g2 = BipartiteFactorGraph(Float64, String, Bool)
     for i in 1:5
         add_factor!(g2, "factor$i")
     end
@@ -104,7 +104,7 @@ end
     @test Graphs.density(g2) == 0.0  # No variables means no possible edges
 
     # Test fully connected bipartite graph
-    g3 = BipartiteFactorGraph{Float64, String, Bool}()
+    g3 = BipartiteFactorGraph(Float64, String, Bool)
     for i in 1:3
         add_variable!(g3, Float64(i))
     end
@@ -139,7 +139,7 @@ end
     using BipartiteFactorGraphs
     using Graphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Add nodes
     v1 = add_variable!(g, 1.0)

--- a/test/graph_tests.jl
+++ b/test/graph_tests.jl
@@ -2,20 +2,48 @@
     using BipartiteFactorGraphs
 
     # Test basic construction
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
     @test num_variables(g) == 0
     @test num_factors(g) == 0
 
     # Test construction with specified dictionary type
-    g2 = BipartiteFactorGraph{Int, String, Float64}(Dict)
+    g2 = BipartiteFactorGraph(Int, String, Float64, Dict)
     @test num_variables(g2) == 0
     @test num_factors(g2) == 0
+
+    # Test construction with no types
+    g3 = BipartiteFactorGraph()
+    @test num_variables(g3) == 0
+    @test num_factors(g3) == 0
+end
+
+@testitem "Show method of the BipartiteFactorGraph" begin
+    using BipartiteFactorGraphs
+
+    g = BipartiteFactorGraph(Float64, String, Bool)
+    @test repr(g) == "BipartiteFactorGraph{Float64, String, Bool} with 0 variables, 0 factors, and 0 edges"
+
+    v1 = add_variable!(g, 1.0)
+    f1 = add_factor!(g, "factor1")
+    add_edge!(g, v1, f1, true)
+
+    @test repr(g) == "BipartiteFactorGraph{Float64, String, Bool} with 1 variables, 1 factors, and 1 edges"
+
+    v2 = add_variable!(g, 2.0)
+    f2 = add_factor!(g, "factor2")
+    add_edge!(g, v2, f2, false)
+
+    @test repr(g) == "BipartiteFactorGraph{Float64, String, Bool} with 2 variables, 2 factors, and 2 edges"
+
+    add_edge!(g, v2, f1, true)
+
+    @test repr(g) == "BipartiteFactorGraph{Float64, String, Bool} with 2 variables, 2 factors, and 3 edges"
 end
 
 @testitem "Adding variables and factors" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Add variables
     v1 = add_variable!(g, 1.0)
@@ -53,7 +81,7 @@ end
 @testitem "Adding edges" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Add nodes
     v1 = add_variable!(g, 1.0)
@@ -92,7 +120,7 @@ end
 @testitem "Neighbors" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Create a simple factor graph
     v1 = add_variable!(g, 1.0)
@@ -135,7 +163,7 @@ end
 @testitem "Collections" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Add nodes
     v1 = add_variable!(g, 1.0)
@@ -148,7 +176,7 @@ end
     @test Set(factors(g)) == Set([f1, f2])
 
     # Test collections with empty graph
-    g_empty = BipartiteFactorGraph{Float64, String, Bool}()
+    g_empty = BipartiteFactorGraph(Float64, String, Bool)
     @test isempty(variables(g_empty))
     @test isempty(factors(g_empty))
 
@@ -162,7 +190,7 @@ end
 @testitem "Type stability" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Add nodes
     v = add_variable!(g, 1.0)
@@ -190,7 +218,7 @@ end
 @testitem "Undirected edge access" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Add nodes
     v1 = add_variable!(g, 1.0)
@@ -236,7 +264,7 @@ end
 @testitem "Complex graph structures" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Create star-like structure: one factor connected to multiple variables
     f_center = add_factor!(g, "center")
@@ -272,7 +300,7 @@ end
 @testitem "Disconnected components" begin
     using BipartiteFactorGraphs
 
-    g = BipartiteFactorGraph{Float64, String, Bool}()
+    g = BipartiteFactorGraph(Float64, String, Bool)
 
     # Create first component
     v1 = add_variable!(g, 1.0)


### PR DESCRIPTION
So the docstrings on the graph creation were actually not displayed in the docs, because it was superseeded by the docstrings of the struct. This PR fixes that, but also changes the construction from `{}` curly-bracked syntax to the argument based syntax. This is more safe if we ever want to change/add/removce the type-parameters in the future (unlikely but still a bit more nicer IMO). As a bonus this PR adds a nice `Base.show` method