### PR TITLE
Make get_data methods be all type-stable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ DictionariesExt = "Dictionaries"
 
 [compat]
 Aqua = "0.8"
+BenchmarkTools = "1.6"
 Dictionaries = "0.4.5"
 Graphs = "1.12.1"
 JET = "0.9, 0.10"
@@ -23,10 +24,11 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Aqua", "Dictionaries", "JET", "Test", "TestItemRunner"]
+test = ["Aqua", "BenchmarkTools", "Dictionaries", "JET", "Test", "TestItemRunner"]

--- a/src/BipartiteFactorGraphs.jl
+++ b/src/BipartiteFactorGraphs.jl
@@ -96,7 +96,7 @@ struct BipartiteFactorGraph{
     E,
     DVars <: AbstractDict{Int, TVar},
     DFacs <: AbstractDict{Int, TFac},
-    DE <: AbstractDict{UnorderedPair, E}
+    DE <: AbstractDict{UnorderedPair{Int}, E}
 }
     graph::SimpleGraph{Int}
     variable_data::DVars
@@ -111,7 +111,7 @@ end
 function BipartiteFactorGraph(::Type{TVar}, ::Type{TFac}, ::Type{E}, dict_type::Type{D} = Dict) where {TVar, TFac, E, D}
     VariableDictType = make_dict_type(dict_type, Int, TVar)
     FactorDictType = make_dict_type(dict_type, Int, TFac)
-    EdgeDictType = make_dict_type(dict_type, UnorderedPair, E)
+    EdgeDictType = make_dict_type(dict_type, UnorderedPair{Int}, E)
     return BipartiteFactorGraph{TVar, TFac, E, VariableDictType, FactorDictType, EdgeDictType}(
         SimpleGraph{Int}(), VariableDictType(), FactorDictType(), EdgeDictType()
     )

--- a/test/graph_tests.jl
+++ b/test/graph_tests.jl
@@ -377,3 +377,26 @@ end
     @test get_variable_data.(g, variables(g)) == collect(Iterators.map(v -> get_variable_data(g, v), variables(g)))
     @test get_factor_data.(g, factors(g)) == collect(Iterators.map(f -> get_factor_data(g, f), factors(g)))
 end
+
+@testitem "`get_data_*` methods should be type-stable" begin
+    using BipartiteFactorGraphs
+    using JET
+    using BenchmarkTools
+
+    g = BipartiteFactorGraph(Float64, String, Vector{Float64})
+    v1 = add_variable!(g, 1.0)
+    f1 = add_factor!(g, "factor1")
+    add_edge!(g, v1, f1, [1.0, 2.0, 3.0])
+
+    @test get_variable_data(g, v1) == 1.0
+    @test get_factor_data(g, f1) == "factor1"
+    @test get_edge_data(g, v1, f1) == [1.0, 2.0, 3.0]
+
+    JET.@test_opt get_variable_data(g, v1)
+    JET.@test_opt get_factor_data(g, f1)
+    JET.@test_opt get_edge_data(g, v1, f1)
+
+    @test @ballocated(get_variable_data($g, $v1)) == 0
+    @test @ballocated(get_factor_data($g, $f1)) == 0
+    @test @ballocated(get_edge_data($g, $v1, $f1)) == 0
+end


### PR DESCRIPTION
There was a missing type-parameter for `UnorderedPair`, which made edge data access type-unstable. This PR fixes that.